### PR TITLE
Replace non-existent _.isInteger function with regex match

### DIFF
--- a/checkit.js
+++ b/checkit.js
@@ -303,7 +303,7 @@ umd(function(_, promiseLib, promiseImpl) {
   // Validation helpers & regex
 
   function checkInt(val) {
-    if (!_.isInteger(val))
+    if (!val.match(Checkit.regex.integer))
       throw new Error("The validator argument must be a valid integer");
   }
 


### PR DESCRIPTION
Fixes `checkInt` function which was breaking all length rules
