### PR TITLE
Rename isNumeric -> numeric

### DIFF
--- a/checkit.js
+++ b/checkit.js
@@ -300,7 +300,7 @@ factory(function(_, createError, Promise) {
     },
 
     // Check if the value is numeric
-    isNumeric: function(val) {
+    numeric: function(val) {
       return !isNaN(parseFloat(val)) && isFinite(val);
     }
 
@@ -321,7 +321,7 @@ factory(function(_, createError, Promise) {
   }
 
   function checkNumber(val) {
-    if (!Validators.isNumeric(val))
+    if (!Validators.numeric(val))
       throw new Error("The validator argument must be a valid number");
   }
 

--- a/test/spec.js
+++ b/test/spec.js
@@ -123,21 +123,21 @@ describe('Checkit', function() {
     describe('numeric', function() {
       it('should only pass for numbers for negative numbers and strings', function(ok) {
         handler(Checkit({
-          negativeInteger: 'isNumeric',
-          negativeStringInteger: 'isNumeric'
+          negativeInteger: 'numeric',
+          negativeStringInteger: 'numeric'
         }).run(testBlock), ok);
       });
 
       it('should pass for positive numbers and strings', function(ok) {
         handler(Checkit({
-          integer: 'isNumeric',
-          stringInteger: 'isNumeric'
+          integer: 'numeric',
+          stringInteger: 'numeric'
         }).run(testBlock), ok);
       });
 
       it('should fail for NaN', function(ok) {
         handler(Checkit({
-          isNaN: 'isNumeric'
+          isNaN: 'numeric'
         }).run(testBlock), ok, function() {});
       });
 


### PR DESCRIPTION
The documentation uses 'numeric', and that makes more sense as a name than 'isNumeric', in context of the other validators.
