### PR TITLE
Compatibility for lodash 4.x

### DIFF
--- a/core.js
+++ b/core.js
@@ -551,7 +551,13 @@ function assembleValidation(validation) {
     var splitRule = validation.rule.split(':');
     validation.rule = splitRule[0];
     if (_.isEmpty(validation.params)) {
-      validation.params = _.rest(splitRule);
+      try {
+        validation.params = _.rest(splitRule);
+      } catch(e) {
+        // We are likely using a version of lodash >= 4, where _.rest has been renamed to _.tail
+        validation.params = _.tail(splitRule);
+      }
+
     }
   } else if (!_.isFunction(validation.rule)) {
     throw new TypeError('Invalid validation');

--- a/core.js
+++ b/core.js
@@ -555,7 +555,12 @@ function assembleValidation(validation) {
         validation.params = _.rest(splitRule);
       } catch(e) {
         // We are likely using a version of lodash >= 4, where _.rest has been renamed to _.tail
-        validation.params = _.tail(splitRule);
+        if(_.tail) {
+          validation.params = _.tail(splitRule);
+        } else {
+          throw e;
+        }
+
       }
 
     }


### PR DESCRIPTION
Since _.rest expects a function as input (formerly _.restParam), I added an exception driven test to use _.tail instead.

*package.json* not updated, still using lodash 3. Travis build seems to be ok.