### PR TITLE
allow promise based custom validators utilize custom messages

### DIFF
--- a/core.js
+++ b/core.js
@@ -144,7 +144,13 @@ Runner.prototype.run = function(target, context) {
       var pending = []
       _.each(validationHash, function(validations, key) {
         _.each(validations, function(validation) {
-          pending.push(processItemAsync(runner, validation, key, context).catch(addError(errors, key, validation)))
+          pending.push(processItemAsync(runner, validation, key, context)
+            .then(function(result) {
+              if (_.isBoolean(result) && result === false) {
+                throw new ValidationError(runner.checkit.getMessage(validation, key));
+              }
+            })
+            .catch(addError(errors, key, validation)))
         })
       })
       return Promise.all(pending)


### PR DESCRIPTION
Currently the only way to trigger a custom validation failure that utilizes "promises"
is to explicitly `throw new Error()` with a message and this does not play well
on the off chance you want to utilize custom messages or localized error messages. The code below demonstrates how its currently done.

```js
Checkit.Validator.prototype.unused = function() {
  return knex(table).where(column, '=', val)
    .andWhere('id', '<>', this._target.id)
    .then(function(resp) {
      if (resp.length > 0) {
        throw new Error('The ' + table + '.' + column + ' field is already in use.');
      }
    });
};
```

The changes made allows you to do this

```js
Checkit.i18n.en.messages.unsued = '{{label}}: {{var_1}} is already in use.';

Checkit.Validator.prototype.unused = function() {
  return knex(table).where(column, '=', val)
    .andWhere('id', '<>', this._target.id)
    .then(function(resp) {
      if (resp.length > 0) {
        return false; // Changes
      }
    });
};
```

Returning a falsey value will either use custom rule object message
or localized message (default behavior without promises).