### PR TITLE
Pass context to conditional function in "maybe" clause

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,7 +334,7 @@ Then use the `maybe` method to add additional rules:
 
 ### .maybe(rules, handler)
 
-The first of the `maybe` method is the hash of validation fields / settings, similar to the main `Checkit` object. The second argument is a function, evaluated with the object being validated, and if it returns explicitly `true` or with a promise fulfilling with `true`, it will add an additional validator to the `Checkit` object.
+The first of the `maybe` method is the hash of validation fields / settings, similar to the main `Checkit` object. The second argument is a function, evaluated with the object being validated as the first argument and the context passed to run (if any) as a second argument. If it returns explicitly `true` or with a promise fulfilling with `true`, it will add an additional validator to the `Checkit` object.
 
 This method makes building complex conditional validations a snap.
 
@@ -345,6 +345,17 @@ checkit.maybe({authorBio: ['required', 'max:500']}, function(input) {
   return input.books > 5;
 });
 ```
+
+
+```js
+// In this example, the "authorBio" field is only required if specified by the context
+checkit.maybe({authorBio: ['required', 'max:500']}, function(input, context) {
+  return context.requireBio;
+});
+
+checkit.run(someObj, { requireBio: true })
+```
+
 
 ## Advanced &amp; Custom Validators:
 

--- a/core.js
+++ b/core.js
@@ -175,7 +175,7 @@ function addVerifiedConditional(validations, conditional) {
 // either by returning `true` or a fulfilled promise.
 function checkConditional(runner, conditional) {
   try {
-    return conditional[1].call(runner, runner.target);
+    return conditional[1].call(runner, runner.target, runner.context);
   } catch (e) {}
 }
 

--- a/test/spec.js
+++ b/test/spec.js
@@ -426,8 +426,23 @@ describe('Checkit', function() {
 
     it('matches', function() {
       return Checkit({matchesEmail: ['matchesField:email']}).validate(testBlock)
-    })
+    });
+  });
 
+  describe('conditional items that depend on context', function() {
+
+    it('passes the context to the conditional', function() {
+      var context = { foo: 'my context', bar: 'another field' };
+      var res = null;
+      return Checkit({})
+      .maybe({}, function(item, context) { 
+        res = context;
+      })
+      .run({}, context)
+      .then(function() {
+        deepEqual(res, context);
+      });
+    });
   });
 
   describe('nested items', function(){

--- a/test/sync.js
+++ b/test/sync.js
@@ -405,6 +405,22 @@ describe('Checkit - sync', function() {
 
   });
 
+  describe('conditional items that depend on context', function() {
+
+    it('passes the context to the conditional', function() {
+      var context = { foo: 'my context', bar: 'another field' };
+      var res = null;
+      Checkit({})
+      .maybe({}, function(item, context) { 
+        res = context;
+      })
+      .runSync({}, context);
+      deepEqual(res, context);
+    });
+  });
+
+
+
   describe('nested items', function(){
     it('validates for nested items', function(){
       return Checkit({"info.email": ['required', 'email']}).runSync({info: {email: "joe@gmail.com"}})


### PR DESCRIPTION
Use case: Implementing a "get" method which fetches an object by certain parameters. 

- An admin should be able to fetch any object by id, irrespective of the owner. So { id } shall be a valid params object
- However, a normal user shall only be allowed to issue the request scoped to its own objects. So { id, user_id } shall be a valid params object and { id } should be invalid.

I am passing the user in the context object to the rules.run method. However, currently the context can't be evaluated in the conditional function of the 'maybe' clause.

This small pull request enhances the signature of the conditional function and allows the above use case to be implemented as:

```
const rules = new Checkit({
    id: ['integer'],
    user_id: ['integer', (val, context) => context.user.admin || context.user.id === val],
    name: ['string']
})
.maybe({ user_id: 'required' }, (id, context) => !context.user.admin);
```

Then, validation is run using 

```
paramRules.run(params, { user })
.then(...)
```

Let me know what you think, I appreciate any feedback!

