### PR TITLE
Set stack traces correctly for custom errors

### DIFF
--- a/test/spec.js
+++ b/test/spec.js
@@ -435,7 +435,7 @@ describe('Checkit', function() {
       var context = { foo: 'my context', bar: 'another field' };
       var res = null;
       return Checkit({})
-      .maybe({}, function(item, context) { 
+      .maybe({}, function(item, context) {
         res = context;
       })
       .run({}, context)
@@ -450,6 +450,15 @@ describe('Checkit', function() {
       return Checkit({
         "info.email": ['required', 'email']
       }).run({info: {email: "joe@gmail.com"}})
+    });
+  });
+
+  describe('stack traces', function(){
+    it('sets the stack trace correctly', function(){
+      return Checkit({ email: ['email'] }).run({ email: 'tim@tgriesser' }).catch(function(err) {
+        equal(err instanceof Checkit.Error, true);
+        equal(/CheckitError: 1 invalid values/.test(err.stack), true);
+      });
     });
   });
 


### PR DESCRIPTION
I noticed in my app that the stack traces for instances of `CheckitError` indicate where the error function was defined, rather than where it is raised. I tracked this down to `CheckitError.prototype.stack` being set via `CheckitError.prototype = new Error`.

To fix, I added some logic to abstract the process of creating a custom error type, and to calculate the stack trace when created, using `Error.captureStackTrace` if available, or via a cleaned version of `new Error(msg).stack` otherwise.